### PR TITLE
fix: モバイルUIレビューの修正および不正テレメトリコードの除去

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="ja" suppressHydrationWarning>
-      <body className={cn("min-h-screen bg-background font-sans antialiased", inter.className)}>
+      <body className={cn("min-h-screen overflow-x-hidden bg-background font-sans antialiased", inter.className)}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
           <AuthProvider>
             <ConditionalAuthGuard>

--- a/src/components/flavors/flavor-create-form.tsx
+++ b/src/components/flavors/flavor-create-form.tsx
@@ -274,10 +274,11 @@ export function FlavorCreateForm({ brands }: FlavorCreateFormProps) {
               <p className="text-xs text-muted-foreground">PNG/JPEG/WEBP、最大5MBまで。</p>
             </div>
           </div>
-          <div className="flex justify-end gap-3">
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-3">
             <Button
               type="reset"
               variant="ghost"
+              className="w-full sm:w-auto"
               onClick={() => {
                 setFormState(INITIAL_STATE);
                 if (fileInputRef.current) {
@@ -288,7 +289,7 @@ export function FlavorCreateForm({ brands }: FlavorCreateFormProps) {
             >
               リセット
             </Button>
-            <Button type="submit" disabled={!canSubmit || isPending}>
+            <Button type="submit" disabled={!canSubmit || isPending} className="w-full sm:w-auto">
               {isPending ? "登録中..." : "フレーバーを登録"}
             </Button>
           </div>

--- a/src/components/flavors/flavors-explorer.tsx
+++ b/src/components/flavors/flavors-explorer.tsx
@@ -362,9 +362,6 @@ export function FlavorsExplorer({
   }, [items, supabase]);
 
   const filteredFlavors = useMemo(() => {
-    // #region agent log
-    const startTime = Date.now();
-    // #endregion
     const normalizedQuery = deferredQuery.trim().toLowerCase();
     const normalizedTags = activeTags.map((tag) => tag.trim().toLowerCase()).filter((tag) => tag.length > 0);
     const normalizedBrand = activeBrand.trim();
@@ -411,9 +408,6 @@ export function FlavorsExplorer({
 
       return a.name.localeCompare(b.name, "ja");
     });
-    // #region agent log
-    fetch('http://127.0.0.1:7242/ingest/627f6a83-0837-4204-a620-6f09c7612d3e',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'flavors-explorer.tsx:filteredFlavors',message:'フィルタリング完了',data:{duration:Date.now()-startTime,total:items.length,filtered:result.length,query:deferredQuery},timestamp:Date.now(),sessionId:'debug-session',hypothesisId:'D'})}).catch(()=>{});
-    // #endregion
     return result;
   }, [activeBrand, activeTags, deferredQuery, items, sort]);
 
@@ -787,7 +781,7 @@ export function FlavorsExplorer({
               }}
             />
             <Select value={sort} onValueChange={handleSortChange}>
-              <SelectTrigger id="flavor-sort" className="w-[140px]">
+              <SelectTrigger id="flavor-sort" className="w-[110px] sm:w-[140px]">
                 <SelectValue placeholder="並び替え" />
               </SelectTrigger>
               <SelectContent>

--- a/src/components/header/nav-menu.tsx
+++ b/src/components/header/nav-menu.tsx
@@ -36,28 +36,28 @@ export function NavMenu() {
           <nav className="flex flex-col gap-1 text-sm">
             <Link
               href="/flavors"
-              className="rounded-md px-3 py-2 hover:bg-accent hover:text-accent-foreground"
+              className="rounded-md px-3 py-2.5 hover:bg-accent hover:text-accent-foreground min-h-[44px] flex items-center"
               onClick={() => setOpen(false)}
             >
               Flavors
             </Link>
             <Link
               href="/sessions"
-              className="rounded-md px-3 py-2 hover:bg-accent hover:text-accent-foreground"
+              className="rounded-md px-3 py-2.5 hover:bg-accent hover:text-accent-foreground min-h-[44px] flex items-center"
               onClick={() => setOpen(false)}
             >
               My records
             </Link>
             <Link
               href="/terms"
-              className="rounded-md px-3 py-2 hover:bg-accent hover:text-accent-foreground"
+              className="rounded-md px-3 py-2.5 hover:bg-accent hover:text-accent-foreground min-h-[44px] flex items-center"
               onClick={() => setOpen(false)}
             >
               利用規約
             </Link>
             <Link
               href="/privacy"
-              className="rounded-md px-3 py-2 hover:bg-accent hover:text-accent-foreground"
+              className="rounded-md px-3 py-2.5 hover:bg-accent hover:text-accent-foreground min-h-[44px] flex items-center"
               onClick={() => setOpen(false)}
             >
               プライバシー

--- a/src/components/navigation/bottom-nav.tsx
+++ b/src/components/navigation/bottom-nav.tsx
@@ -102,7 +102,7 @@ export function BottomNav() {
                 key={item.href}
                 href={item.href}
                 className={cn(
-                  "flex flex-1 flex-col items-center justify-center gap-1 rounded-lg px-2 py-1.5 transition-colors",
+                  "flex flex-1 flex-col items-center justify-center gap-1 rounded-lg px-2 py-1.5 min-h-[44px] transition-colors",
                   active
                     ? "text-primary"
                     : "text-muted-foreground hover:text-foreground"

--- a/src/components/sessions/floating-record-button.tsx
+++ b/src/components/sessions/floating-record-button.tsx
@@ -22,7 +22,7 @@ export function FloatingRecordButton() {
 
   return (
     <div
-      className="fixed bottom-7 right-3 sm:right-5 z-50 flex flex-col items-end"
+      className="fixed bottom-20 right-3 sm:bottom-7 sm:right-5 z-50 flex flex-col items-end"
       onMouseLeave={() => setOpen(false)}
     >
       <div

--- a/src/components/sessions/home-sessions-calendar.tsx
+++ b/src/components/sessions/home-sessions-calendar.tsx
@@ -719,10 +719,9 @@ export function HomeSessionsCalendar() {
                 {daySummary.timeRange ? <p className="text-xs text-muted-foreground">{daySummary.timeRange}</p> : null}
               </div>
             </div>
-            </div>
             <ScrollArea className="flex-1 min-h-0 px-4 pb-6 sm:px-6">
             <div className="space-y-4">
-              <div className="grid gap-3 sm:grid-cols-3 grid-cols-2">
+              <div className="grid grid-cols-3 gap-2 sm:gap-3">
               <Card className="rounded-3xl border border-border/60 bg-background/80 shadow-sm">
                 <CardContent className="space-y-1 p-3 sm:p-4">
                   <p className="text-xs text-muted-foreground">記録件数</p>
@@ -1334,6 +1333,7 @@ export function HomeSessionsCalendar() {
               </div>
             </div>
             </ScrollArea>
+          </div>
         </DialogContent>
       </Dialog>
       <Dialog

--- a/src/components/sessions/session-form.tsx
+++ b/src/components/sessions/session-form.tsx
@@ -467,7 +467,7 @@ export function SessionForm() {
                       <div>
                         <Label className="text-sm font-semibold">フレーバー #{index + 1}</Label>
                         {isSelected && selectedFlavor && (
-                          <p className="text-xs text-muted-foreground truncate max-w-[150px]">{selectedFlavor.brand?.name ?? "ブランド未設定"}</p>
+                          <p className="text-xs text-muted-foreground truncate max-w-[120px] sm:max-w-[200px]">{selectedFlavor.brand?.name ?? "ブランド未設定"}</p>
                         )}
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- タップターゲットを44px以上に修正（nav-menu, bottom-nav）
- floating-record-buttonとボトムナビの重なりを解消
- 固定幅をレスポンシブ指定に変更（session-form, flavors-explorer）
- flavor-create-formのボタンをモバイルで縦積みに
- home-sessions-calendarの統計カード3列化とJSX構造修正
- body に overflow-x-hidden 追加
- flavors-explorerの不正テレメトリコード（localhost:7242へのfetch）を除去

🤖 Generated with [Claude Code](https://claude.com/claude-code)