### PR TITLE
fix: iOS Safari auto-zoom prevention via font-size + CSS scale trick

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -114,3 +114,16 @@ html[data-scroll-animate="true"] .scroll-fade.is-visible {
     transition: none;
   }
 }
+
+/* iOS Safari: font-size < 16px triggers auto-zoom on input focus.
+   Fix: keep font-size at 16px and scale down visually (14/16 = 0.875)
+   so the input appears as text-sm while preventing the zoom. */
+@supports (-webkit-touch-callout: none) {
+  .ios-input-fix {
+    font-size: 16px !important;
+    transform: scale(0.875) !important;
+    transform-origin: left center !important;
+    width: calc(100% / 0.875) !important;
+    margin-right: calc(100% * (1 - 1 / 0.875)) !important;
+  }
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type,
     <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ios-input-fix",
         className
       )}
       ref={ref}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ios-input-fix",
         className
       )}
       ref={ref}


### PR DESCRIPTION
Inputs with font-size < 16px trigger auto-zoom on focus in iOS Safari.
Rather than bumping the design to 16px, keep font-size at 16px and
apply transform: scale(0.875) so the input visually matches text-sm (14px).
Width and margin-right are adjusted to preserve layout dimensions.

https://claude.ai/code/session_01YQYWCRAvCfFy9Nyfn4aznF